### PR TITLE
Update gitignore to ignore node_modules correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-./node_modules
+/node_modules


### PR DESCRIPTION
Realized that the .gitignore had node_modules added incorrectly. Fixed that so we won't have issues with it going forward